### PR TITLE
extend document type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 + commentedTimestamp
 ```
 
+- `Document` interface now accepts an optional second parameter for the status property of the document. See [PR #461](https://github.com/ExtraHorizon/javascript-sdk/pull/461)
+
 ## [v5.1.0]
 
 ### Added

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -328,11 +328,11 @@ export interface Index {
 
 export type IndexInput = Pick<Index, 'fields' | 'options'>;
 
-export interface Document<CustomData = null> {
+export interface Document<CustomData = null, CustomStatus = null> {
   id?: ObjectId;
   userIds?: ObjectId[];
   groupIds?: ObjectId[];
-  status?: string;
+  status?: CustomStatus extends null ? string : CustomStatus;
   data?: CustomData extends null ? Record<string, unknown> : CustomData;
   transitionLock?: {
     timestamp?: Date;
@@ -505,11 +505,11 @@ export interface DataDocumentsService {
    * @returns {Document} document
    * @throws {IllegalArgumentError}
    */
-  create<CustomData = null>(
+  create<CustomData = null, CustomStatus = null>(
     schemaId: ObjectId,
     requestBody: Record<string, any>,
     options?: OptionsWithRql & { gzip?: boolean }
-  ): Promise<Document<CustomData>>;
+  ): Promise<Document<CustomData, CustomStatus>>;
   /**
    * Request a list of documents
    *
@@ -538,10 +538,10 @@ export interface DataDocumentsService {
    * @param rql Add filters to the requested list.
    * @returns PagedResultWithPager<Document>
    */
-  find<CustomData = null>(
+  find<CustomData = null, CustomStatus = null>(
     schemaId: ObjectId,
     options?: OptionsWithRql
-  ): Promise<PagedResultWithPager<Document<CustomData>>>;
+  ): Promise<PagedResultWithPager<Document<CustomData, CustomStatus>>>;
   /**
    * Request a list of all documents
    *
@@ -572,10 +572,10 @@ export interface DataDocumentsService {
    * @param rql Add filters to the requested list.
    * @returns Document[]
    */
-  findAll<CustomData = null>(
+  findAll<CustomData = null, CustomStatus = null>(
     schemaId: ObjectId,
     options?: OptionsWithRql
-  ): Promise<Document<CustomData>[]>;
+  ): Promise<Document<CustomData, CustomStatus>[]>;
   /**
    * Request a list of all documents and return a generator
    *
@@ -604,10 +604,13 @@ export interface DataDocumentsService {
    * @param rql Add filters to the requested list.
    * @returns Document[]
    */
-  findAllIterator<CustomData = null>(
+  findAllIterator<CustomData = null, CustomStatus = null>(
     schemaId: ObjectId,
     options?: OptionsWithRql
-  ): AsyncGenerator<PagedResult<Document<CustomData>>, Record<string, never>>;
+  ): AsyncGenerator<
+    PagedResult<Document<CustomData, CustomStatus>>,
+    Record<string, never>
+  >;
   /**
    * Shortcut method to find a document by id
    *
@@ -618,11 +621,11 @@ export interface DataDocumentsService {
    * @param rql an optional rql string
    * @returns {Document} document
    */
-  findById<CustomData = null>(
+  findById<CustomData = null, CustomStatus = null>(
     schemaId: ObjectId,
     documentId: ObjectId,
     options?: OptionsWithRql
-  ): Promise<Document<CustomData>>;
+  ): Promise<Document<CustomData, CustomStatus>>;
   /**
    * Returns the first document that is found with the applied filter
    *
@@ -631,10 +634,10 @@ export interface DataDocumentsService {
    * @param rql an optional rql string
    * @returns {Document} document
    */
-  findFirst<CustomData = null>(
+  findFirst<CustomData = null, CustomStatus = null>(
     schemaId: ObjectId,
     options?: OptionsWithRql
-  ): Promise<Document<CustomData>>;
+  ): Promise<Document<CustomData, CustomStatus>>;
   /**
    * Update a document
    *


### PR DESCRIPTION
In stead of 
```ts
type MeasurementStatus =
  | 'measured'
  | 'preprocessing_selection'
  | 'analysis_selection'
  | 'pending_analysis'
  | 'under_analysis'
  | 'analysis_failed'
  | 'processing_results'
  | 'analyzed'
  | 'pending_review'
  | 'reviewed';

type Measurement = Document<MeasurementData> & {
  status: MeasurementStatus;
};
```

you can now do

```ts
type MeasurementStatus =
  | 'measured'
  | 'preprocessing_selection'
  | 'analysis_selection'
  | 'pending_analysis'
  | 'under_analysis'
  | 'analysis_failed'
  | 'processing_results'
  | 'analyzed'
  | 'pending_review'
  | 'reviewed';
type Measurement = Document<MeasurementData, MeasurementStatus>;
```

Which helps when using it like this

```ts
const measurement = await sdk.data.documents.findById<MeasurementData,MeasurementStatus>(schema.id, measurmentId);

if (measurement.status === 'measured') { <-- status will be typed
  // do something
}
```