### PR TITLE
Reconfigure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: 'wednesday'
       time: '00:00'
       timezone: 'Europe/Brussels'
+    allow:
+      - dependency-type: production
     commit-message:
       prefix: '[DEPENDABOT]'
     labels:
@@ -14,5 +16,6 @@ updates:
       - 'dependabot'
     open-pull-requests-limit: 10
     reviewers:
-      - 'jensdev'
+      - 'ThomasReyskens'
+      - 'FilipAben'
     versioning-strategy: 'increase'


### PR DESCRIPTION
* Change reviewers
* Only check dependencies for production packages, not dev dependencies