### PR TITLE
TOOL-42: removed partial from return type from userdata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extrahorizon/javascript-sdk",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "This package serves as a JavaScript wrapper around all Extra Horizon cloud services.",
   "main": "build/index.cjs.js",
   "types": "build/types/index.d.ts",

--- a/src/services/users/types.ts
+++ b/src/services/users/types.ts
@@ -30,7 +30,7 @@ export interface UserData {
   updateTimestamp: Date;
 }
 
-export type User = Partial<UserData>;
+export type User = UserData;
 
 export type UserDataUpdate = Partial<
   Pick<


### PR DESCRIPTION
Reason:
A user should have UserData. e.g. you can't have a user without a userId, meaning it should be mandatory, not optional.