### PR TITLE
SVCS-866 Moved provider operations to their own sub-service

### DIFF
--- a/src/services/auth/oidc/index.ts
+++ b/src/services/auth/oidc/index.ts
@@ -1,73 +1,21 @@
 import { HttpInstance } from '../../../types';
 import { HttpClient } from '../../http-client';
 import { OidcLinkRequestBody, OidcService } from './types';
+import providers from './providers';
 import loginAttempts from './loginAttempts';
 
 export default (
   oidcClient: HttpClient,
   httpWithAuth: HttpInstance
 ): OidcService => ({
-  async createProvider(requestBody) {
-    const { data } = await oidcClient.post(
-      httpWithAuth,
-      `/oidc/providers`,
-      requestBody
-    );
-    return data;
-  },
-
-  async getProviders(options) {
-    const { data } = await oidcClient.get(
-      httpWithAuth,
-      `/oidc/providers${options?.rql || ''}`,
-      options
-    );
-    return data;
-  },
-
-  async updateProvider(providerId, requestBody) {
-    const { data } = await oidcClient.put(
-      httpWithAuth,
-      `/oidc/providers/${providerId}`,
-      requestBody
-    );
-    return data;
-  },
-
-  async deleteProvider(providerId) {
-    const { data } = await oidcClient.delete(
-      httpWithAuth,
-      `/oidc/providers/${providerId}`
-    );
-    return data;
-  },
-
-  async enableProvider(providerId: string) {
-    const { data } = await oidcClient.post(
-      httpWithAuth,
-      `/oidc/providers/${providerId}/enable`,
-      {}
-    );
-    return data;
-  },
-
-  async disableProvider(providerId: string) {
-    const { data } = await oidcClient.post(
-      httpWithAuth,
-      `/oidc/providers/${providerId}/disable`,
-      {}
-    );
-    return data;
-  },
-
   async linkUserToOidcProvider(
     providerName: string,
-    linkRequestBody: OidcLinkRequestBody
+    body: OidcLinkRequestBody
   ) {
     const { data } = await oidcClient.post(
       httpWithAuth,
       `/oidc/providers/${providerName}/link`,
-      { ...linkRequestBody }
+      body
     );
     return data;
   },
@@ -81,5 +29,6 @@ export default (
     return data;
   },
 
+  providers: providers(oidcClient, httpWithAuth),
   loginAttempts: loginAttempts(oidcClient, httpWithAuth),
 });

--- a/src/services/auth/oidc/loginAttempts/types.ts
+++ b/src/services/auth/oidc/loginAttempts/types.ts
@@ -34,7 +34,7 @@ export interface LoginAttemptsService {
   findAllIterator(options?: OptionsWithRql): FindAllIterator<LoginAttempt>;
 
   /**
-   * ## Retrieve a list of login attempts
+   * ## Retrieve the first queried login attempt
    *
    * **Global Permissions:**
    * - `VIEW_OIDC_LOGIN_ATTEMPTS` - Allows a user to view login attempts

--- a/src/services/auth/oidc/providers/index.ts
+++ b/src/services/auth/oidc/providers/index.ts
@@ -1,0 +1,83 @@
+import { HttpClient } from '../../../http-client';
+import { HttpInstance } from '../../../../http/types';
+import { OidcProvider, OidcProviderService } from './types';
+import { addPagersFn, findAllGeneric, findAllIterator } from '../../../helpers';
+import { OptionsWithRql } from '../../../types';
+
+export default (
+  oidcClient: HttpClient,
+  httpWithAuth: HttpInstance
+): OidcProviderService => {
+  async function query(options: OptionsWithRql) {
+    const { data } = await oidcClient.get(
+      httpWithAuth,
+      `/oidc/providers${options?.rql || ''}`,
+      options
+    );
+    return data;
+  }
+
+  return {
+    async create(body) {
+      const { data } = await oidcClient.post(
+        httpWithAuth,
+        `/oidc/providers`,
+        body
+      );
+      return data;
+    },
+
+    async find(options) {
+      const result = await query(options);
+      return addPagersFn<OidcProvider>(query, options, result);
+    },
+
+    async findAll(options?: OptionsWithRql) {
+      return findAllGeneric<OidcProvider>(query, options);
+    },
+
+    findAllIterator(options?: OptionsWithRql) {
+      return findAllIterator<OidcProvider>(query, options);
+    },
+
+    async findFirst(options?: OptionsWithRql) {
+      const result = await query(options);
+      return result.data[0];
+    },
+
+    async update(providerId, body) {
+      const { data } = await oidcClient.put(
+        httpWithAuth,
+        `/oidc/providers/${providerId}`,
+        body
+      );
+      return data;
+    },
+
+    async enable(providerId: string) {
+      const { data } = await oidcClient.post(
+        httpWithAuth,
+        `/oidc/providers/${providerId}/enable`,
+        {}
+      );
+      return data;
+    },
+
+    async disable(providerId: string) {
+      const { data } = await oidcClient.post(
+        httpWithAuth,
+        `/oidc/providers/${providerId}/disable`,
+        {}
+      );
+      return data;
+    },
+
+    async delete(providerId) {
+      const { data } = await oidcClient.delete(
+        httpWithAuth,
+        `/oidc/providers/${providerId}`
+      );
+      return data;
+    },
+  };
+};

--- a/src/services/auth/oidc/providers/types.ts
+++ b/src/services/auth/oidc/providers/types.ts
@@ -1,0 +1,210 @@
+import {
+  AffectedRecords,
+  OptionsWithRql,
+  PagedResultWithPager,
+} from '../../../types';
+import { FindAllIterator } from '../../../helpers';
+
+export interface OidcProviderService {
+  /**
+   * ## Create a new OpenID Connect Provider
+   * ###You can use this function to create a new OpenId Connect Provider to enable Single Sign On.
+   *
+   * **Global Permissions:**
+   * `CREATE_OIDC_PROVIDER` - Allows a user to create a new OpenID Connect Provider
+   *
+   * @param body {@link OidcProviderCreation}
+   * @returns OidcProvider {@link OidcProvider}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   * @throws {@link FieldFormatError} when one of the provided parameters is not correctly formatted according to the documentation.
+   */
+  create(body: OidcProviderCreation): Promise<OidcProviderResponse>;
+
+  /**
+   * ## Retrieve a paged list of OpenID Connect providers
+   *
+   * **Global Permissions:**
+   * - `VIEW_OIDC_PROVIDERS` - Allows a user to view OpenID Connect providers
+   * @param options {@link OptionsWithRql} - Add filters to the requested list
+   * @returns A paged list of providers {@link PagedResultWithPager PagedResultWithPager<OidcProvider>}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   */
+  find(options?: OptionsWithRql): Promise<PagedResultWithPager<OidcProvider>>;
+
+  /**
+   * ## Retrieve a list of all OpenID Connect providers
+   *
+   * **Global Permissions:**
+   * - `VIEW_OIDC_PROVIDERS` - Allows a user to view OpenID Connect providers
+   * @param options {@link OptionsWithRql} - Add filters to the requested list
+   * @returns An array of providers {@link OidcProvider OidcProvider[]}
+   * @throws {@link Error} Do not pass in limit operator with findAll
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   */
+  findAll(options?: OptionsWithRql): Promise<OidcProvider[]>;
+
+  /**
+   * ## Retrieve a paged list of OpenID Connect providers
+   *
+   * **Global Permissions:**
+   * - `VIEW_OIDC_PROVIDERS` - Allows a user to view OpenID Connect providers
+   * @param options {@link OptionsWithRql} - Add filters to the requested list
+   * @returns An iterator for the queried providers {@link FindAllIterator FindAllIterator<OidcProvider>}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   */
+  findAllIterator(options?: OptionsWithRql): FindAllIterator<OidcProvider>;
+
+  /**
+   * ## Retrieve the first queried OpenID Connect provider
+   *
+   * **Global Permissions:**
+   * - `VIEW_OIDC_PROVIDERS` - Allows a user to view OpenID Connect providers
+   * @param options {@link OptionsWithRql} - Add filters to the requested list
+   * @returns The first element of the queried providers {@link OidcProvider}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   */
+  findFirst(options?: OptionsWithRql): Promise<OidcProvider>;
+
+  /**
+   * ## Update an OpenID Connect provider
+   * ###You can use this function to update an existing OpenId Connect Provider. Fields left undefined will not be updated.
+   *
+   * **Global Permissions:**
+   * - `UPDATE_OIDC_PROVIDER` - Allows a user to update an OpenID Connect provider
+   *
+   * @param providerId {@link string} - The Extra Horizon provider id
+   * @param body {@link OidcProviderUpdate} - The set of updatable fields for an existing provider
+   * @returns An affected records promise {@link AffectedRecords}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
+   * @throws {@link FieldFormatError} when one of the provided parameters is not correctly formatted according to the documentation.
+   */
+  update(
+    providerId: string,
+    body: OidcProviderUpdate
+  ): Promise<AffectedRecords>;
+
+  /**
+   * ## Delete an OpenID Connect provider
+   * ###You can use this function to delete an existing OpenId Connect provider.
+   *
+   * **Global Permissions:**
+   * - `DELETE_OIDC_PROVIDER` - Allows a user to delete an OpenID Connect provider
+   *
+   * @param providerId {@link string} - The Extra Horizon provider id
+   * @returns An affected records response {@link AffectedRecords}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
+   * @throws {@link IllegalStateError} when the provider is enabled (Only disabled providers can be removed) or when there are still users linked to this provider.
+   */
+  delete(providerId: string): Promise<AffectedRecords>;
+
+  /**
+   * ## Enable an OpenID Connect provider
+   *
+   * **Global Permissions:**
+   * - `UPDATE_OIDC_PROVIDER` - Allows a user to update an OpenID Connect provider
+   *
+   * @param providerId {@link string} - The Extra Horizon provider id
+   * @returns An affected records response {@link AffectedRecords}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
+   */
+  enable(providerId: string): Promise<AffectedRecords>;
+
+  /**
+   * ## Disable an OpenID Connect provider
+   *
+   * **Global Permissions:**
+   * - `UPDATE_OIDC_PROVIDER` - Allows a user to update an OpenID Connect provider
+   *
+   * @param providerId - The Extra Horizon provider id
+   * @returns An affected records response {@link AffectedRecords}
+   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
+   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
+   */
+  disable(providerId: string): Promise<AffectedRecords>;
+}
+
+export interface OidcProvider {
+  /** ###The Extra Horizon OpenID Connect provider identifier */
+  id: string;
+  /** ###The user-friendly and unique name of the provider
+   * **Validation:**
+   * - Minimum Length: 3 characters
+   * - Maximum Length: 40 characters
+   * - Matches pattern: /^[a-zA-Z0-9_-]+$/ */
+  name: string;
+  /** ###A brief description of the provider
+   * **Validation:**
+   * - Maximum Length: 256 characters */
+  description: string;
+  /**  ###Obtained from the OpenID Connect application on registration (client_id)
+   * **Validation:**
+   * - Maximum Length: 256 characters */
+  clientId: string;
+  /**  ###Obtained from the OpenID Connect application on registration (Issuer / iss)
+   * **Validation:**
+   * - Maximum Length: 2048 characters */
+  issuerId: string;
+  /**  ###Allows a user to sign in to the OpenID Connect application and retrieve an authorization_code
+   * **Validation:**
+   * - The user can sign in to retrieve an authorization_code
+   * - Maximum Length: 2048 characters
+   *
+   * **Notes:**
+   * - The authorization endpoint is obtained from the OpenID application on registration
+   * */
+  authorizationEndpoint: string;
+  /**
+   * ###ALlows a user to exchange an authorization_code for access tokens with the provider
+   * **Validation:**
+   * - Maximum length: 2048 characters
+   *
+   * **Notes:**
+   * - The token endpoint is obtained from the OpenID application on registration
+   */
+  tokenEndpoint: string;
+  /**
+   * ###ALlows a user to exchange an authorization_code for personal information with the provider
+   *
+   * **Validation:**
+   * - Maximum length: 2048 characters
+   *
+   * **Notes:**
+   * - The user info endpoint is obtained from the OpenID application on registration
+   * - The returned user information is defined by the OpenID Connect provider */
+  userinfoEndpoint: string;
+  /**
+   * ###Redirects the user to the provided URL after a successful user sign in
+   *
+   * **Validation:**
+   * - Must match a redirect URL provided to the OpenID connect application on creation
+   * - Maximum length: 2048 characters
+   * */
+  redirectUri: string;
+  /** ### Indicates if the OpenID Connect provider is active
+   * **Notes:**
+   * - Disabling a provider will not remove the users linked to it
+   * - Disabling a provider will not terminate active user sessions
+   * */
+  enabled: boolean;
+  /** ###  Obtained from the OpenID Connect application on registration (client_secret)
+   * **validation:**
+   * - Maximum Length: 2048 characters */
+  clientSecret: string;
+  /** ###The creation timestamp of the OpenID Connect provider */
+  creationTimestamp: Date;
+  /** ###The last updated timestamp of the OpenID Connect provider */
+  updateTimestamp: Date;
+}
+
+export type OidcProviderCreation = Omit<
+  OidcProvider,
+  'id' | 'enabled' | 'creationTimestamp' | 'updateTimestamp'
+>;
+export type OidcProviderResponse = Omit<OidcProvider, 'clientSecret'> & {
+  /** ###The last four characters of the client secret */
+  clientSecretHint: string;
+};
+export type OidcProviderUpdate = Partial<OidcProviderCreation>;

--- a/src/services/auth/oidc/providers/types.ts
+++ b/src/services/auth/oidc/providers/types.ts
@@ -18,7 +18,7 @@ export interface OidcProviderService {
    * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
    * @throws {@link FieldFormatError} when one of the provided parameters is not correctly formatted according to the documentation.
    */
-  create(body: OidcProviderCreation): Promise<OidcProviderResponse>;
+  create(body: OidcProviderCreation): Promise<OidcProvider>;
 
   /**
    * ## Retrieve a paged list of OpenID Connect providers
@@ -127,84 +127,50 @@ export interface OidcProviderService {
 }
 
 export interface OidcProvider {
-  /** ###The Extra Horizon OpenID Connect provider identifier */
+  /** A 24 character long hexadecimal value acting as the identifier of an OpenId Connect provider */
   id: string;
-  /** ###The user-friendly and unique name of the provider
-   * **Validation:**
-   * - Minimum Length: 3 characters
-   * - Maximum Length: 40 characters
-   * - Matches pattern: /^[a-zA-Z0-9_-]+$/ */
+  /** Human friendly name of the provider, which can also be used in the oidc login url. Then name can be between 3 and 40 characters and match pattern: '/^[a-zA-Z0-9_-]+$/' */
   name: string;
-  /** ###A brief description of the provider
-   * **Validation:**
-   * - Maximum Length: 256 characters */
+  /** Description of the provider. With a maximum of 256 characters */
   description: string;
-  /**  ###Obtained from the OpenID Connect application on registration (client_id)
-   * **Validation:**
-   * - Maximum Length: 256 characters */
+  /** Provided by the OpenID Connect provider after registration. With a maximum of 2048 characters */
   clientId: string;
-  /**  ###Obtained from the OpenID Connect application on registration (Issuer / iss)
-   * **Validation:**
-   * - Maximum Length: 2048 characters */
+  /** A URL of maximum 2048 charactes that acts as a unique identifier for the provider. `Issuer` in the provider's discovery document. */
   issuerId: string;
-  /**  ###Allows a user to sign in to the OpenID Connect application and retrieve an authorization_code
-   * **Validation:**
-   * - The user can sign in to retrieve an authorization_code
-   * - Maximum Length: 2048 characters
-   *
-   * **Notes:**
-   * - The authorization endpoint is obtained from the OpenID application on registration
-   * */
+  /** A URL of maximum 2048 character that points to the provider’s URL for authorising the user (i.e., signing the user in). authorization_endpoint in the provider's discovery document. */
   authorizationEndpoint: string;
-  /**
-   * ###ALlows a user to exchange an authorization_code for access tokens with the provider
-   * **Validation:**
-   * - Maximum length: 2048 characters
-   *
-   * **Notes:**
-   * - The token endpoint is obtained from the OpenID application on registration
-   */
+  /** A URL of maximum 2048 character that points to the provider’s OAuth 2.0 protected URL from which user information can be obtained. token_endpoint in the provider's discovery document. */
   tokenEndpoint: string;
-  /**
-   * ###ALlows a user to exchange an authorization_code for personal information with the provider
-   *
-   * **Validation:**
-   * - Maximum length: 2048 characters
-   *
-   * **Notes:**
-   * - The user info endpoint is obtained from the OpenID application on registration
-   * - The returned user information is defined by the OpenID Connect provider */
+  /** A URL of maximum 2048 character that points to the provider’s endpoint of the authorization server Extra Horizon can use to obtain the email address and optionally also the family name and given name. userinfo_endpoint in the provider's discovery document. */
   userinfoEndpoint: string;
-  /**
-   * ###Redirects the user to the provided URL after a successful user sign in
-   *
-   * **Validation:**
-   * - Must match a redirect URL provided to the OpenID connect application on creation
-   * - Maximum length: 2048 characters
-   * */
+  /** A URL of maximum 2048 character that points to the location where the authorization server sends the user once the app has been successfully authorised and granted an authorization code or access token */
   redirectUri: string;
-  /** ### Indicates if the OpenID Connect provider is active
-   * **Notes:**
-   * - Disabling a provider will not remove the users linked to it
-   * - Disabling a provider will not terminate active user sessions
-   * */
+  /** Indicates wether the OpenID Connect provider is active and can be used for SSO */
   enabled: boolean;
-  /** ###  Obtained from the OpenID Connect application on registration (client_secret)
-   * **validation:**
-   * - Maximum Length: 2048 characters */
-  clientSecret: string;
-  /** ###The creation timestamp of the OpenID Connect provider */
+  /** The last four characters of the client secret */
+  clientSecretHint: string;
+  /** The creation timestamp of the OpenID Connectprovider */
   creationTimestamp: Date;
-  /** ###The last updated timestamp of the OpenID Connect provider */
+  /** The update timestamp of the OpenID Connect provider */
   updateTimestamp: Date;
 }
 
-export type OidcProviderCreation = Omit<
-  OidcProvider,
-  'id' | 'enabled' | 'creationTimestamp' | 'updateTimestamp'
->;
-export type OidcProviderResponse = Omit<OidcProvider, 'clientSecret'> & {
-  /** ###The last four characters of the client secret */
-  clientSecretHint: string;
-};
+export interface OidcProviderCreation
+  extends Required<
+    Pick<
+      OidcProvider,
+      | 'name'
+      | 'description'
+      | 'clientId'
+      | 'authorizationEndpoint'
+      | 'redirectUri'
+      | 'tokenEndpoint'
+      | 'userinfoEndpoint'
+      | 'issuerId'
+    >
+  > {
+  /** The OAuth 2.0 Client Secret you received from your provider. Max 2048 characters */
+  clientSecret: string;
+}
+
 export type OidcProviderUpdate = Partial<OidcProviderCreation>;

--- a/src/services/auth/oidc/types.ts
+++ b/src/services/auth/oidc/types.ts
@@ -1,185 +1,45 @@
-import { AffectedRecords, OptionsWithRql, PagedResult } from '../../types';
+import { AffectedRecords } from '../../types';
 import { LoginAttemptsService } from './loginAttempts/types';
+import { OidcProviderService } from './providers/types';
 
 export interface OidcService {
   /**
-   * ## Create a new OpenId Connect Provider
-   * You can use this function to create a new OpenId Connect Provider to enable Single Sign On.
+   * ##Link the authenticated user to a provider
+   * ###You can use this function to link the currently logged-in user to a registered provider.
    *
-   * #### Global Permissions
-   * `CREATE_OIDC_PROVIDER` - Is required to use this function and provides you with the ability to create new OIDC Providers.
+   * **Default Permissions:**
+   * - Any authenticated user can execute this function.
    *
-   * @param requestBody {@link OidcProviderCreation}
-   * @returns OidcProvider {@link OidcProvider}
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   * @throws {@link FieldFormatError} when one of the provided parameters is not correctly formatted according to the documentation.
-   */
-  createProvider(requestBody: OidcProviderCreation): Promise<OidcProvider>;
-
-  /**
-   * ## Get a list OpenId connect providers
-   * You can use this function to retrieve a paginated list of configured OpenId Connect Providers.
-   *
-   * #### Global Permissions
-   * `VIEW_OIDC_PROVIDERS` - Is required to use this function and provides you with the ability to retrieve a paginated list.
-   *
-   * @param options {@link OptionsWithRql} addional options with rql that can be set for your request to the cluster.
-   * @returns Returns a promise of a {@link PagedResult} with {@link OidcProvider}'s
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   */
-  getProviders(options?: OptionsWithRql): Promise<PagedResult<OidcProvider>>;
-
-  /**
-   * ## Update an openId Connect Provider
-   * You can use this function to update an existing OpenId Connect Provider. Fields left undefined will not be updated.
-   *
-   * #### Global Permissions
-   * `UPDATE_OIDC_PROVIDER` - Is required to use this function and provides you with the ability to update, enable or disable existing providers.
-   *
-   * @param providerId A 24 character long hexadecimal value acting as the identifier of an OpenId Connect provider.
-   * @param requestBody {@link OidcProviderUpdate} A set of updatable fields for existing providers.
-   * @returns Returns a promise of a {@link AffectedRecords}.
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
-   * @throws {@link FieldFormatError} when one of the provided parameters is not correctly formatted according to the documentation.
-   */
-  updateProvider(
-    providerId: string,
-    requestBody: OidcProviderUpdate
-  ): Promise<AffectedRecords>;
-
-  /**
-   * ## Delete an OpenId Connect Provider
-   * You can use this function to delete an existing OpenId Connect provider.
-   *
-   * #### Global Permissions
-   * `DELETE_OIDC_PROVIDER` - Is required to use this function and provides you with the ability to delete existing OpenId Connect providers.
-   *
-   * @param providerId A 24 character long hexadecimal value acting as the identifier of an OpenId Connect provider.
-   * @returns Returns a promise of a {@link AffectedRecords}.
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
-   * @throws {@link IllegalStateError} when the provider is enabled (Only dissaled providers can be removed) or when there are still users linked to this provider.
-   */
-  deleteProvider(providerId: string): Promise<AffectedRecords>;
-
-  /**
-   * ## Enable an OpenId Connect Provider
-   * You can use this function to enable an existing OpenId Connect provider. When a provider is enabled client applications will be able to authenticate users using this provider.
-   *
-   * #### Global Permissions
-   * `UPDATE_OIDC_PROVIDER` - Is required to use this function and provides you with the ability to update, enable or disable existing providers.
-   *
-   * @param providerId A 24 character long hexadecimal value acting as the identifier of an OpenId Connect provider.
-   * @returns Returns a promise of a {@link AffectedRecords}.
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
-   */
-  enableProvider(providerId: string): Promise<AffectedRecords>;
-
-  /**
-   * ## Disable an OpenId Connect Provider
-   * You can use this function to disable an existing OpenId Connect provider. When a provider is disabled client applications will no longer be able to authenticate users using this provider.
-   * When disabled the {@link linkUserToOidcProvider}, {@link generateOidcAuthenticationUrl} the {@link authenticateWithOidc} functions will return an IllegalStateError.
-   * Make sure these clients correctly handle these error's or make sure to update your frontend before disabling.
-   *
-   * #### Global Permissions
-   * `UPDATE_OIDC_PROVIDER` - Is required to use this function and provides you with the ability to update, enable or disable existing providers.
-   *
-   * @param providerId A 24 character long hexadecimal value acting as the identifier of an OpenId Connect provider.
-   * @returns Returns a promise of a {@link AffectedRecords}.
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   * @throws {@link ResourceUnknownError} when no provider is found for the specified providerId.
-   */
-  disableProvider(providerId: string): Promise<AffectedRecords>;
-
-  /**
-   * ## Link the authenticated user to an OIDC provider
-   * You can use this function to link the authenticated user to a registered OpenId Connect Provider.
-   *
-   * #### Default Permissions
-   * Every authenticated users can use this function.
-   *
-   * @param providerName The name of the OpenID Connect provider that the user will be linked to.
-   * @param linkRequestBody
-   * @returns Returns a promise of a {@link AffectedRecords}.
+   * @param providerName {@link string} The name of the OpenID Connect provider to link the user to
+   * @param data {@link OidcLinkRequestBody} - The link to OpenID Connect provider data
+   * @returns An affected records response {@link AffectedRecords}
    * @throws {@link IllegalStateError} when the provider is disabled. The provider must be enabled to link a user.
    * @throws {@link ResourceUnknownError} when no provider is found for the specified providerName.
-   * */
+   */
   linkUserToOidcProvider(
     providerName: string,
-    linkRequestBody: OidcLinkRequestBody
+    data: OidcLinkRequestBody
   ): Promise<AffectedRecords>;
 
   /**
-   * ## Unlink a user from openID connect
-   * You can use this function to unlink a user from an OpenId Connect Provider.
+   * ##Unlink a user from OpenID Connect
+   * ###You can use this function to unlink a user from an OpenId Connect Provider.
    *
-   * #### Global Permissions
-   * `UNLINK_USER_FROM_OIDC`- Is required to use this function and provides you with the ability to unlink the OpenId Connect provider from a user.
+   * **Global Permissions:**
+   * - `UNLINK_USER_FROM_OIDC` - Allows a user to unlink users from OpenID Connect
    *
-   * @param userId The id of the user to be unlinked from OpenID Connect
-   * @returns Returns a promise of a {@link AffectedRecords}.
-   * @throws {@link NoPermissionError} when the user doesn't have the required permissions to execute the function.
-   * @throws {@link ResourceUnknownError} when no user is found for the specified userId.
+   * @param userId {@link string} - The Extra Horizon id of the user to be unlinked from OpenID Connect
+   * @returns An affected records response {@link AffectedRecords}
    */
   unlinkUserFromOidc(userId: string): Promise<AffectedRecords>;
 
+  providers: OidcProviderService;
   loginAttempts: LoginAttemptsService;
 }
 
-export interface OidcProvider {
-  /** A 24 character long hexadecimal value acting as the identifier of an OpenId Connect provider */
-  id: string;
-  /** Human friendly name of the provider, which can also be used in the oidc login url. Then name can be between 3 and 40 characters and match pattern: '/^[a-zA-Z0-9_-]+$/' */
-  name: string;
-  /** Description of the provider. With a maximum of 256 characters */
-  description: string;
-  /** Provided by the OpenID Connect provider after registration. With a maximum of 2048 characters */
-  clientId: string;
-  /** A URL of maximum 2048 charactes that acts as a unique identifier for the provider. `Issuer` in the provider's discovery document. */
-  issuerId: string;
-  /** A URL of maximum 2048 character that points to the provider’s URL for authorising the user (i.e., signing the user in). authorization_endpoint in the provider's discovery document. */
-  authorizationEndpoint: string;
-  /** A URL of maximum 2048 character that points to the provider’s OAuth 2.0 protected URL from which user information can be obtained. token_endpoint in the provider's discovery document. */
-  tokenEndpoint: string;
-  /** A URL of maximum 2048 character that points to the provider’s endpoint of the authorization server Extra Horizon can use to obtain the email address and optionally also the family name and given name. userinfo_endpoint in the provider's discovery document. */
-  userinfoEndpoint: string;
-  /** A URL of maximum 2048 character that points to the location where the authorization server sends the user once the app has been successfully authorised and granted an authorization code or access token */
-  redirectUri: string;
-  /** Indicates wether the OpenID Connect provider is active and can be used for SSO */
-  enabled: boolean;
-  /** The last four characters of the client secret */
-  clientSecretHint: string;
-  /** The creation timestamp of the OpenID Connectprovider */
-  creationTimestamp: Date;
-  /** The update timestamp of the OpenID Connect provider */
-  updateTimestamp: Date;
-}
-
-export interface OidcProviderCreation
-  extends Required<
-    Pick<
-      OidcProvider,
-      | 'name'
-      | 'description'
-      | 'clientId'
-      | 'authorizationEndpoint'
-      | 'redirectUri'
-      | 'tokenEndpoint'
-      | 'userinfoEndpoint'
-      | 'issuerId'
-    >
-  > {
-  /** The OAuth 2.0 Client Secret you received from your provider. Max 2048 characters */
-  clientSecret: string;
-}
-
-export type OidcProviderUpdate = Partial<OidcProviderCreation>;
-
 export interface OidcLinkRequestBody {
-  /** Obtained from the OpenID Connect provider upon successful user login. */
+  /** ###The users Extra Horizon presence token - Obtained from {@link AuthService.confirmPresence confirmPresence} */
+  presenceToken: string;
+  /** ###Obtained from the OpenID Connect application upon successful user login. */
   authorizationCode: string;
-  /** Optional: include the nonce if it was provided in the authentication request */
-  nonce?: string;
 }

--- a/tests/unit/auth/providers/index.ts
+++ b/tests/unit/auth/providers/index.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import nock from 'nock';
-import { createClient, rqlBuilder } from '../../../src';
-import { AUTH_BASE } from '../../../src/constants';
+import { createClient, rqlBuilder } from '../../../../src';
+import { AUTH_BASE } from '../../../../src/constants';
 
-describe('Auth - OpenID Connect', () => {
+describe('Auth - OpenID Connect - Providers', () => {
   const host = 'https://api.xxx.extrahorizon.com';
 
   const sdk = createClient({
@@ -49,7 +49,7 @@ describe('Auth - OpenID Connect', () => {
       .post(`/oidc/providers`, data)
       .reply(200, providerResponse);
 
-    const result = await sdk.auth.oidc.createProvider(data);
+    const result = await sdk.auth.oidc.providers.create(data);
     expect(result).toMatchObject(provider);
   });
 
@@ -62,7 +62,7 @@ describe('Auth - OpenID Connect', () => {
         data: [providerResponse, providerResponse, providerResponse],
       });
 
-    const { data } = await sdk.auth.oidc.getProviders({ rql });
+    const { data } = await sdk.auth.oidc.providers.find({ rql });
     expect(data).toMatchObject([provider, provider, provider]);
   });
 
@@ -71,7 +71,7 @@ describe('Auth - OpenID Connect', () => {
       .put(`/oidc/providers/${provider.id}`, { name: 'google-v2' })
       .reply(200, { affectedRecords: 1 });
 
-    const result = await sdk.auth.oidc.updateProvider(provider.id, {
+    const result = await sdk.auth.oidc.providers.update(provider.id, {
       name: 'google-v2',
     });
     expect(result).toMatchObject({ affectedRecords: 1 });
@@ -82,7 +82,7 @@ describe('Auth - OpenID Connect', () => {
       .delete(`/oidc/providers/${provider.id}`)
       .reply(200, { affectedRecords: 1 });
 
-    const result = await sdk.auth.oidc.deleteProvider(provider.id);
+    const result = await sdk.auth.oidc.providers.delete(provider.id);
     expect(result).toMatchObject({ affectedRecords: 1 });
   });
 
@@ -91,7 +91,7 @@ describe('Auth - OpenID Connect', () => {
       .post(`/oidc/providers/${provider.id}/enable`)
       .reply(200, { affectedRecords: 1 });
 
-    const result = await sdk.auth.oidc.enableProvider(provider.id);
+    const result = await sdk.auth.oidc.providers.enable(provider.id);
     expect(result).toMatchObject({ affectedRecords: 1 });
   });
 
@@ -100,14 +100,14 @@ describe('Auth - OpenID Connect', () => {
       .post(`/oidc/providers/${provider.id}/disable`)
       .reply(200, { affectedRecords: 1 });
 
-    const result = await sdk.auth.oidc.disableProvider(provider.id);
+    const result = await sdk.auth.oidc.providers.disable(provider.id);
     expect(result).toMatchObject({ affectedRecords: 1 });
   });
 
   it('Links a user to an OpenID Connect provider', async () => {
     const linkRequestBody = {
+      presenceToken: 'some-randomly-generated-token',
       authorizationCode: 'some-randomly-generated-string',
-      nonce: 'some-randomly-generated-string',
     };
 
     nock(`${host}${AUTH_BASE}`)


### PR DESCRIPTION
- Updated tests to match sub-service
- Removed deprecated nonce]
- Added presence token
- Updated documentation
- Refactored provider model to match database