### PR TITLE
SVCS-559 Corrected the inline documentation syntax for some titles

### DIFF
--- a/src/services/auth/oidc/providers/types.ts
+++ b/src/services/auth/oidc/providers/types.ts
@@ -8,7 +8,7 @@ import { FindAllIterator } from '../../../helpers';
 export interface OidcProviderService {
   /**
    * ## Create a new OpenID Connect Provider
-   * ###You can use this function to create a new OpenId Connect Provider to enable Single Sign On.
+   * ### You can use this function to create a new OpenId Connect Provider to enable Single Sign On.
    *
    * **Global Permissions:**
    * `CREATE_OIDC_PROVIDER` - Allows a user to create a new OpenID Connect Provider
@@ -67,7 +67,7 @@ export interface OidcProviderService {
 
   /**
    * ## Update an OpenID Connect provider
-   * ###You can use this function to update an existing OpenId Connect Provider. Fields left undefined will not be updated.
+   * ### You can use this function to update an existing OpenId Connect Provider. Fields left undefined will not be updated.
    *
    * **Global Permissions:**
    * - `UPDATE_OIDC_PROVIDER` - Allows a user to update an OpenID Connect provider
@@ -86,7 +86,7 @@ export interface OidcProviderService {
 
   /**
    * ## Delete an OpenID Connect provider
-   * ###You can use this function to delete an existing OpenId Connect provider.
+   * ### You can use this function to delete an existing OpenId Connect provider.
    *
    * **Global Permissions:**
    * - `DELETE_OIDC_PROVIDER` - Allows a user to delete an OpenID Connect provider

--- a/src/services/auth/oidc/types.ts
+++ b/src/services/auth/oidc/types.ts
@@ -4,8 +4,8 @@ import { OidcProviderService } from './providers/types';
 
 export interface OidcService {
   /**
-   * ##Link the authenticated user to a provider
-   * ###You can use this function to link the currently logged-in user to a registered provider.
+   * ## Link the authenticated user to a provider
+   * ### You can use this function to link the currently logged-in user to a registered provider.
    *
    * **Default Permissions:**
    * - Any authenticated user can execute this function.
@@ -22,8 +22,8 @@ export interface OidcService {
   ): Promise<AffectedRecords>;
 
   /**
-   * ##Unlink a user from OpenID Connect
-   * ###You can use this function to unlink a user from an OpenId Connect Provider.
+   * ## Unlink a user from OpenID Connect
+   * ### You can use this function to unlink a user from an OpenId Connect Provider.
    *
    * **Global Permissions:**
    * - `UNLINK_USER_FROM_OIDC` - Allows a user to unlink users from OpenID Connect
@@ -38,8 +38,8 @@ export interface OidcService {
 }
 
 export interface OidcLinkRequestBody {
-  /** ###The users Extra Horizon presence token - Obtained from {@link AuthService.confirmPresence confirmPresence} */
+  /** ### The users Extra Horizon presence token - Obtained from {@link AuthService.confirmPresence confirmPresence} */
   presenceToken: string;
-  /** ###Obtained from the OpenID Connect application upon successful user login. */
+  /** ### Obtained from the OpenID Connect application upon successful user login. */
   authorizationCode: string;
 }


### PR DESCRIPTION
If the `#` are attached to the text it won't render properly in the VS Code Markdown renderer