### PR TITLE
Make some RegisterUserData type fields optional

### DIFF
--- a/src/services/users/types.ts
+++ b/src/services/users/types.ts
@@ -83,9 +83,9 @@ export interface RegisterUserData {
   email: string;
   password: string;
   phoneNumber: string;
-  birthday: string;
-  gender: Gender;
-  country: string;
+  birthday?: string;
+  gender?: Gender;
+  country?: string;
   region?: string;
   language: string;
   timeZone?: string;


### PR DESCRIPTION
Some fields in the `RegisterUserData` type are marked as required even though they are not required by the register endpoint in the API. 

This PR fixes that, and only requires the required parameters for registering a user.