### PR TITLE
SVCS-444 Corrected where the name of a schema can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using an oAuth2 confidential client on web no longer causes a `global not defined` error
 - `exh.files.create` and `exh.files.createFromText` now work correctly while using oAuth1 in React Native
 - The generic `API_ERROR` name is no longer shown for errors with more specific information available
-- Type corrections for the user, file, index and mfa entities 
+- Type corrections for the user, file, index and mfa entities
+- Corrected the places where the name of a schema can also be used rather than just the id
 
 ## [8.1.1]
 

--- a/src/services/data/comments.ts
+++ b/src/services/data/comments.ts
@@ -7,57 +7,57 @@ export default (
   client: HttpClient,
   httpAuth: HttpInstance
 ): DataCommentsService => ({
-  async create(schemaId, documentId, requestBody, options) {
+  async create(schemaIdOrName, documentId, requestBody, options) {
     return (
       await client.post(
         httpAuth,
-        `/${schemaId}/documents/${documentId}/comments`,
+        `/${schemaIdOrName}/documents/${documentId}/comments`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async find(schemaId, documentId, options) {
+  async find(schemaIdOrName, documentId, options) {
     return (
       await client.get(
         httpAuth,
-        `/${schemaId}/documents/${documentId}/comments${options?.rql || ''}`,
+        `/${schemaIdOrName}/documents/${documentId}/comments${options?.rql || ''}`,
         options
       )
     ).data;
   },
 
-  async findById(this: DataCommentsService, id, schemaId, documentId, options) {
+  async findById(this: DataCommentsService, id, schemaIdOrName, documentId, options) {
     const rqlWithId = rqlBuilder(options?.rql).eq('id', id).build();
-    const res = await this.find(schemaId, documentId, {
+    const res = await this.find(schemaIdOrName, documentId, {
       ...options,
       rql: rqlWithId,
     });
     return res.data[0];
   },
 
-  async findFirst(this: DataCommentsService, schemaId, documentId, options) {
-    const res = await this.find(schemaId, documentId, options);
+  async findFirst(this: DataCommentsService, schemaIdOrName, documentId, options) {
+    const res = await this.find(schemaIdOrName, documentId, options);
     return res.data[0];
   },
 
-  async update(commentId, schemaId, documentId, requestBody, options) {
+  async update(commentId, schemaIdOrName, documentId, requestBody, options) {
     return (
       await client.put(
         httpAuth,
-        `/${schemaId}/documents/${documentId}/comments/${commentId}`,
+        `/${schemaIdOrName}/documents/${documentId}/comments/${commentId}`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async remove(commentId, schemaId, documentId, options) {
+  async remove(commentId, schemaIdOrName, documentId, options) {
     return (
       await client.delete(
         httpAuth,
-        `/${schemaId}/documents/${documentId}/comments/${commentId}`,
+        `/${schemaIdOrName}/documents/${documentId}/comments/${commentId}`,
         options
       )
     ).data;

--- a/src/services/data/documents.ts
+++ b/src/services/data/documents.ts
@@ -9,13 +9,13 @@ export default (
   client: HttpClient,
   httpAuth: HttpInstance
 ): DataDocumentsService => {
-  function partialApplyFind(schemaId) {
+  function partialApplyFind(schemaIdOrName) {
     return async options => {
       const baseConfig = options?.headers ? { headers: options.headers } : {};
       return (
         await client.get(
           httpAuth,
-          `/${schemaId}/documents${options?.rql || ''}`,
+          `/${schemaIdOrName}/documents${options?.rql || ''}`,
           { ...baseConfig, customResponseKeys: ['data.data'] }
         )
       ).data;
@@ -25,7 +25,7 @@ export default (
   return {
     // TypeScript limitation. Function using optional generic with fallback can not be first function.
     async assertNonLockedState(
-      schemaId,
+      schemaIdOrName,
       documentId,
       tries = 5,
       retryTimeInMs = 300,
@@ -35,7 +35,7 @@ export default (
         throw new Error('Document is in a locked state');
       }
 
-      const res = await this.findById(schemaId, documentId, options);
+      const res = await this.findById(schemaIdOrName, documentId, options);
       if (!res.transitionLock) {
         return true;
       }
@@ -43,7 +43,7 @@ export default (
       await delay(retryTimeInMs);
 
       return this.assertNonLockedState(
-        schemaId,
+        schemaIdOrName,
         documentId,
         tries - 1,
         retryTimeInMs,
@@ -51,12 +51,12 @@ export default (
       );
     },
 
-    async create(schemaId, requestBody, options) {
+    async create(schemaIdOrName, requestBody, options) {
       const baseConfig = options?.headers ? { headers: options.headers } : {};
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents`,
+          `/${schemaIdOrName}/documents`,
           requestBody,
           {
             ...baseConfig,
@@ -67,57 +67,57 @@ export default (
       ).data;
     },
 
-    async find(schemaId, options) {
-      const result = await partialApplyFind(schemaId)(options);
-      return addPagersFn<Document>(partialApplyFind(schemaId), options, result);
+    async find(schemaIdOrName, options) {
+      const result = await partialApplyFind(schemaIdOrName)(options);
+      return addPagersFn<Document>(partialApplyFind(schemaIdOrName), options, result);
     },
 
-    async findAll(this: DataDocumentsService, schemaId, options) {
-      return findAllGeneric<Document>(partialApplyFind(schemaId), options);
+    async findAll(this: DataDocumentsService, schemaIdOrName, options) {
+      return findAllGeneric<Document>(partialApplyFind(schemaIdOrName), options);
     },
 
-    findAllIterator(schemaId, options) {
-      return findAllIterator<Document>(partialApplyFind(schemaId), options);
+    findAllIterator(schemaIdOrName, options) {
+      return findAllIterator<Document>(partialApplyFind(schemaIdOrName), options);
     },
 
-    async findById(this: DataDocumentsService, schemaId, documentId, options?) {
+    async findById(this: DataDocumentsService, schemaIdOrName, documentId, options?) {
       const rqlWithId = rqlBuilder(options?.rql).eq('id', documentId).build();
-      const res = await this.find(schemaId, { ...options, rql: rqlWithId });
+      const res = await this.find(schemaIdOrName, { ...options, rql: rqlWithId });
 
       return res.data[0];
     },
 
-    async findFirst(this: DataDocumentsService, schemaId, options) {
-      const res = await this.find(schemaId, options);
+    async findFirst(this: DataDocumentsService, schemaIdOrName, options) {
+      const res = await this.find(schemaIdOrName, options);
       return res.data[0];
     },
 
-    async update(schemaId, documentId, requestBody, options) {
+    async update(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.put(
           httpAuth,
-          `/${schemaId}/documents/${documentId}${options?.rql || ''}`,
+          `/${schemaIdOrName}/documents/${documentId}${options?.rql || ''}`,
           requestBody,
           options
         )
       ).data;
     },
 
-    async remove(schemaId, documentId, options) {
+    async remove(schemaIdOrName, documentId, options) {
       return (
         await client.delete(
           httpAuth,
-          `/${schemaId}/documents/${documentId}`,
+          `/${schemaIdOrName}/documents/${documentId}`,
           options
         )
       ).data;
     },
 
-    async removeFields(schemaId, documentId, requestBody, options) {
+    async removeFields(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents/${documentId}/deleteFields${
+          `/${schemaIdOrName}/documents/${documentId}/deleteFields${
             options?.rql || ''
           }`,
           requestBody,
@@ -126,11 +126,11 @@ export default (
       ).data;
     },
 
-    async transition(schemaId, documentId, requestBody, options) {
+    async transition(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents/${documentId}/transition${
+          `/${schemaIdOrName}/documents/${documentId}/transition${
             options?.rql || ''
           }`,
           requestBody,
@@ -139,44 +139,44 @@ export default (
       ).data;
     },
 
-    async linkGroups(schemaId, documentId, requestBody, options) {
+    async linkGroups(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents/${documentId}/linkGroups`,
+          `/${schemaIdOrName}/documents/${documentId}/linkGroups`,
           requestBody,
           options
         )
       ).data;
     },
 
-    async unlinkGroups(schemaId, documentId, requestBody, options) {
+    async unlinkGroups(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents/${documentId}/unlinkGroups`,
+          `/${schemaIdOrName}/documents/${documentId}/unlinkGroups`,
           requestBody,
           options
         )
       ).data;
     },
 
-    async linkUsers(schemaId, documentId, requestBody, options) {
+    async linkUsers(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents/${documentId}/linkUsers`,
+          `/${schemaIdOrName}/documents/${documentId}/linkUsers`,
           requestBody,
           options
         )
       ).data;
     },
 
-    async unlinkUsers(schemaId, documentId, requestBody, options) {
+    async unlinkUsers(schemaIdOrName, documentId, requestBody, options) {
       return (
         await client.post(
           httpAuth,
-          `/${schemaId}/documents/${documentId}/unlinkUsers`,
+          `/${schemaIdOrName}/documents/${documentId}/unlinkUsers`,
           requestBody,
           options
         )

--- a/src/services/data/indexes.ts
+++ b/src/services/data/indexes.ts
@@ -6,15 +6,15 @@ export default (
   client: HttpClient,
   httpAuth: HttpInstance
 ): DataIndexesService => ({
-  async create(schemaId, requestBody, options) {
+  async create(schemaIdOrName, requestBody, options) {
     return (
-      await client.post(httpAuth, `/${schemaId}/indexes`, requestBody, options)
+      await client.post(httpAuth, `/${schemaIdOrName}/indexes`, requestBody, options)
     ).data;
   },
 
-  async remove(indexId, schemaId, options) {
+  async remove(indexId, schemaIdOrName, options) {
     return (
-      await client.delete(httpAuth, `/${schemaId}/indexes/${indexId}`, options)
+      await client.delete(httpAuth, `/${schemaIdOrName}/indexes/${indexId}`, options)
     ).data;
   },
 });

--- a/src/services/data/properties.ts
+++ b/src/services/data/properties.ts
@@ -6,32 +6,32 @@ export default (
   client: HttpClient,
   httpAuth: HttpInstance
 ): DataPropertiesService => ({
-  async create(schemaId, requestBody, options) {
+  async create(schemaIdOrName, requestBody, options) {
     return (
       await client.post(
         httpAuth,
-        `/${schemaId}/properties`,
+        `/${schemaIdOrName}/properties`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async remove(schemaId, propertyPath, options) {
+  async remove(schemaIdOrName, propertyPath, options) {
     return (
       await client.delete(
         httpAuth,
-        `/${schemaId}/properties/${propertyPath}`,
+        `/${schemaIdOrName}/properties/${propertyPath}`,
         options
       )
     ).data;
   },
 
-  async update(schemaId, propertyPath, requestBody, options) {
+  async update(schemaIdOrName, propertyPath, requestBody, options) {
     return (
       await client.put(
         httpAuth,
-        `/${schemaId}/properties/${propertyPath}`,
+        `/${schemaIdOrName}/properties/${propertyPath}`,
         requestBody,
         options
       )

--- a/src/services/data/schemas.ts
+++ b/src/services/data/schemas.ts
@@ -72,24 +72,24 @@ export default (
       return res.data[0];
     },
 
-    async update(schemaId, requestBody, options) {
-      return (await client.put(httpAuth, `/${schemaId}`, requestBody, options))
+    async update(schemaIdOrName, requestBody, options) {
+      return (await client.put(httpAuth, `/${schemaIdOrName}`, requestBody, options))
         .data;
     },
 
-    async remove(schemaId, options) {
-      return (await client.delete(httpAuth, `/${schemaId}`, options)).data;
+    async remove(schemaIdOrName, options) {
+      return (await client.delete(httpAuth, `/${schemaIdOrName}`, options)).data;
     },
 
-    async disable(schemaId, options) {
+    async disable(schemaIdOrName, options) {
       return (
-        await client.post(httpAuth, `/${schemaId}/disable`, undefined, options)
+        await client.post(httpAuth, `/${schemaIdOrName}/disable`, undefined, options)
       ).data;
     },
 
-    async enable(schemaId, options) {
+    async enable(schemaIdOrName, options) {
       return (
-        await client.post(httpAuth, `/${schemaId}/enable`, undefined, options)
+        await client.post(httpAuth, `/${schemaIdOrName}/enable`, undefined, options)
       ).data;
     },
   };

--- a/src/services/data/statuses.ts
+++ b/src/services/data/statuses.ts
@@ -6,26 +6,26 @@ export default (
   client: HttpClient,
   httpAuth: HttpInstance
 ): DataStatusesService => ({
-  async create(schemaId, requestBody, options) {
+  async create(schemaIdOrName, requestBody, options) {
     return (
-      await client.post(httpAuth, `/${schemaId}/statuses`, requestBody, options)
+      await client.post(httpAuth, `/${schemaIdOrName}/statuses`, requestBody, options)
     ).data;
   },
 
-  async update(schemaId, name, requestBody, options) {
+  async update(schemaIdOrName, name, requestBody, options) {
     return (
       await client.put(
         httpAuth,
-        `/${schemaId}/statuses/${name}`,
+        `/${schemaIdOrName}/statuses/${name}`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async remove(schemaId, name, options) {
+  async remove(schemaIdOrName, name, options) {
     return (
-      await client.delete(httpAuth, `/${schemaId}/statuses/${name}`, options)
+      await client.delete(httpAuth, `/${schemaIdOrName}/statuses/${name}`, options)
     ).data;
   },
 });

--- a/src/services/data/transitions.ts
+++ b/src/services/data/transitions.ts
@@ -6,44 +6,44 @@ export default (
   client: HttpClient,
   httpAuth: HttpInstance
 ): DataTransitionsService => ({
-  async updateCreation(schemaId, requestBody, options) {
+  async updateCreation(schemaIdOrName, requestBody, options) {
     return (
       await client.put(
         httpAuth,
-        `/${schemaId}/creationTransition`,
+        `/${schemaIdOrName}/creationTransition`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async create(schemaId, requestBody, options) {
+  async create(schemaIdOrName, requestBody, options) {
     return (
       await client.post(
         httpAuth,
-        `/${schemaId}/transitions`,
+        `/${schemaIdOrName}/transitions`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async update(schemaId, transitionId, requestBody, options) {
+  async update(schemaIdOrName, transitionId, requestBody, options) {
     return (
       await client.put(
         httpAuth,
-        `/${schemaId}/transitions/${transitionId}`,
+        `/${schemaIdOrName}/transitions/${transitionId}`,
         requestBody,
         options
       )
     ).data;
   },
 
-  async remove(schemaId, transitionId, options) {
+  async remove(schemaIdOrName, transitionId, options) {
     return (
       await client.delete(
         httpAuth,
-        `/${schemaId}/transitions/${transitionId}`,
+        `/${schemaIdOrName}/transitions/${transitionId}`,
         options
       )
     ).data;

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -370,14 +370,14 @@ export interface DataCommentsService {
    * none | | Comment on your own documents
    * `CREATE_DOCUMENT_COMMENTS` | `staff enlistment`  | Comment on any document belonging to the group
    * `CREATE_DOCUMENT_COMMENTS` | `global` | Comment on any document
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @param requestBody
    * @returns {Promise<Comment>}
    * @throws {LockedDocumentError}
    */
   create(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       text: CommentText;
@@ -394,39 +394,36 @@ export interface DataCommentsService {
    * none | | View comments for your own documents
    * `VIEW_DOCUMENT_COMMENTS` | `staff enlistment`  | View comments for any document belonging to the group
    * `VIEW_DOCUMENT_COMMENTS` | `global` | View the comments for any document
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
-   * @param rql Add filters to the requested list.
    * @returns {Promise<PagedResult<Comment>>}
    */
   find(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     options?: OptionsWithRql
   ): Promise<PagedResult<Comment>>;
   /**
    * Find By Id
    * @param id the Id to search for
-   * @param schemaId the schema Id
-   * @param documentId the document Id
-   * @param rql an optional rql string
+   * @param schemaIdOrName The id or name of the targeted schema.
+   * @param documentId The id of the targeted document.
    * @returns the first element found
    */
   findById(
     id: ObjectId,
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     options?: OptionsWithRql
   ): Promise<Comment>;
   /**
    * Find First
-   * @param schemaId the schema Id
-   * @param documentId the document Id
-   * @param rql an optional rql string
+   * @param schemaIdOrName The id or name of the targeted schema.
+   * @param documentId The id of the targeted document.
    * @returns the first element found
    */
   findFirst(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     options?: OptionsWithRql
   ): Promise<Comment>;
@@ -440,13 +437,13 @@ export interface DataCommentsService {
    * none | | Update your comments
    * `UPDATE_DOCUMENT_COMMENTS` | `global` | Update comments
    * @param commentId The id of the targeted comment.
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @returns {Promise<AffectedRecords>}
    */
   update(
     commentId: ObjectId,
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       text: CommentText;
@@ -464,13 +461,13 @@ export interface DataCommentsService {
    * `UPDATE_DOCUMENT_COMMENTS` | `staff enlistment`  | Delete comments for any document belonging to the group
    * `UPDATE_DOCUMENT_COMMENTS` | `global` | Delete the comments for any document
    * @param commentId The id of the targeted comment.
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @returns {Promise<AffectedRecords>}
    */
   remove(
     commentId: ObjectId,
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
@@ -482,13 +479,13 @@ export interface DataDocumentsService {
    *
    * Actions cannot be performed if the document has a transitionLock
    *
-   * @param schemaId the schema Id
-   * @param documentId the document Id
+   * @param schemaIdOrName The id or name of the targeted schema.
+   * @param documentId The id of the targeted document.
    * @returns boolean success
    * @throws {Error} If the document is in a locked state after the specified tries
    */
   assertNonLockedState(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     tries: number,
     retryTimeInMs: number,
@@ -502,7 +499,7 @@ export interface DataDocumentsService {
    * none |  | Everyone can use this endpoint
    *
    * `CREATE_DOCUMENTS` | `global` | When the schema.createMode is set to permissionRequired then this permission is required to make a group
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody
    * @returns {Document} document
    * @throws {IllegalArgumentError}
@@ -512,7 +509,7 @@ export interface DataDocumentsService {
     OutputData = null,
     CustomStatus = null
   >(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: InputData,
     options?: OptionsWithRql & { gzip?: boolean; }
   ): Promise<Document<OutputData, CustomStatus>>;
@@ -540,12 +537,11 @@ export interface DataDocumentsService {
    * none | `patient enlistment` | See the documents belonging to the group
    * none | `staff enlistment` | See the documents belonging to the group
    * `VIEW_DOCUMENTS` | `global` | See any document
-   * @param schemaId The id of the targeted schema.
-   * @param rql Add filters to the requested list.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns PagedResultWithPager<Document>
    */
   find<CustomData = null, CustomStatus = null>(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     options?: OptionsWithRql
   ): Promise<PagedResultWithPager<Document<CustomData, CustomStatus>>>;
   /**
@@ -574,12 +570,11 @@ export interface DataDocumentsService {
    * none | `patient enlistment` | See the documents belonging to the group
    * none | `staff enlistment` | See the documents belonging to the group
    * `VIEW_DOCUMENTS` | `global` | See any document
-   * @param schemaId The id of the targeted schema.
-   * @param rql Add filters to the requested list.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns Document[]
    */
   findAll<CustomData = null, CustomStatus = null>(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     options?: OptionsWithRql
   ): Promise<Document<CustomData, CustomStatus>[]>;
   /**
@@ -606,12 +601,11 @@ export interface DataDocumentsService {
    * none | `patient enlistment` | See the documents belonging to the group
    * none | `staff enlistment` | See the documents belonging to the group
    * `VIEW_DOCUMENTS` | `global` | See any document
-   * @param schemaId The id of the targeted schema.
-   * @param rql Add filters to the requested list.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns Document[]
    */
   findAllIterator<CustomData = null, CustomStatus = null>(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     options?: OptionsWithRql
   ): FindAllIterator<Document<CustomData, CustomStatus>>;
   /**
@@ -619,13 +613,12 @@ export interface DataDocumentsService {
    *
    * Same Permissions as the find() method
    *
-   * @param schemaId the schema Id
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId the Id to search for
-   * @param rql an optional rql string
    * @returns {Document} document
    */
   findById<CustomData = null, CustomStatus = null>(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     options?: OptionsWithRql
   ): Promise<Document<CustomData, CustomStatus>>;
@@ -633,12 +626,11 @@ export interface DataDocumentsService {
    * Returns the first document that is found with the applied filter
    *
    * Same Permissions as the find() method
-   * @param schemaId the schema Id
-   * @param rql an optional rql string
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns {Document} document
    */
   findFirst<CustomData = null, CustomStatus = null>(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     options?: OptionsWithRql
   ): Promise<Document<CustomData, CustomStatus>>;
   /**
@@ -651,14 +643,13 @@ export interface DataDocumentsService {
    * none | | Update your own documents
    * none | `staff enlistment`  | Update all the documents belonging to the group
    * `UPDATE_DOCUMENTS` | `global` | Update all the documents
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
-   * @param rql Add filters to the requested list.
    * @param requestBody Record<string, any>
    * @returns AffectedRecords
    */
   update<UpdateData = Record<string, any>>(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: UpdateData,
     options?: OptionsWithRql
@@ -679,12 +670,12 @@ export interface DataDocumentsService {
    * none | | Delete the document if the userId is linked to the document
    * none | `staff enlistment`  | Delete the document if the groupId is linked
    * `DELETE_DOCUMENTS` | `global` | Delete the document
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @returns AffectedRecords
    */
   remove(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
@@ -698,14 +689,13 @@ export interface DataDocumentsService {
    * none | | Update your own documents
    * none | `staff enlistment`  | Update all the documents belonging to the group
    * `UPDATE_DOCUMENTS` | `global` | Update all the documents
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
-   * @param rql Add filters to the requested list.
    * @param requestBody list of fields
    * @returns AffectedRecords
    */
   removeFields(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       fields: Array<string>;
@@ -722,16 +712,15 @@ export interface DataDocumentsService {
    * none | | Update your own documents
    * none | `staff enlistment`  | Update all the documents belonging to the group
    * `UPDATE_DOCUMENTS` | `global` | Update all the documents
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
-   * @param rql Add filters to the requested list.
    * @param requestBody
    * @returns AffectedRecords
    * @throws {IllegalArgumentError}
    * @throws {ResourceUnknownError}
    */
   transition(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       id: ObjectId;
@@ -747,13 +736,13 @@ export interface DataDocumentsService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @param requestBody list of groupIds
    * @returns AffectedRecords
    */
   linkGroups(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       groupIds: Array<ObjectId>;
@@ -772,13 +761,13 @@ export interface DataDocumentsService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @param requestBody list of groupIds
    * @returns AffectedRecords
    */
   unlinkGroups(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       groupIds: Array<ObjectId>;
@@ -795,13 +784,13 @@ export interface DataDocumentsService {
    * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
    *
    * Note: When GroupSyncMode.LINKED_USERS_PATIENT_ENLISTMENT is set for a document, all the groups where the specified user is enlisted as patient will also be added to the document.
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @param requestBody list of userIds
    * @returns AffectedRecords
    */
   linkUsers(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       userIds: Array<ObjectId>;
@@ -822,13 +811,13 @@ export interface DataDocumentsService {
    * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
    *
    * Note: When GroupSyncMode.LINKED_USERS_PATIENT_ENLISTMENT is set for a document, all the groups where the specified user is enlisted as patient will also be removed from the document.
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param documentId The id of the targeted document.
    * @param requestBody list of userIds
    * @returns AffectedRecords
    */
   unlinkUsers(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
       userIds: Array<ObjectId>;
@@ -846,7 +835,7 @@ export interface DataIndexesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global`  | **Required** for this endpoint: Create an index
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody
    * @returns Index Success
    * @throws {ResourceAlreadyExistsError}
@@ -854,7 +843,7 @@ export interface DataIndexesService {
    * @throws {IllegalStateError}
    */
   create(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: IndexInput,
     options?: OptionsBase
   ): Promise<Index>;
@@ -867,14 +856,14 @@ export interface DataIndexesService {
    * - | - | -
    * `UPDATE_SCHEMAS` | `global`  | **Required** for this endpoint: Delete an index
    * @param indexId The id of the targeted index.
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns AffectedRecords
    * @throws {NoPermissionError}
    * @throws {ResourceUnknownError}
    */
   remove(
     indexId: ObjectId,
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
 }
@@ -886,7 +875,7 @@ export interface DataPropertiesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody The name and configuration
    * @returns AffectedRecords
    * @throws {ResourceAlreadyExistsError}
@@ -895,7 +884,7 @@ export interface DataPropertiesService {
    * @throws {ResourceUnknownException}
    */
   create(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: {
       name: string;
       configuration: TypeConfiguration;
@@ -908,14 +897,14 @@ export interface DataPropertiesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param propertyPath The path to the property
    * @returns AffectedRecords
    * @throws {IllegalArgumentError}
    * @throws {ResourceUnknownError}
    */
   remove(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     propertyPath: string,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
@@ -925,7 +914,7 @@ export interface DataPropertiesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param propertyPath The path to the property
    * @param requestBody The configuration
    * @returns AffectedRecords
@@ -933,7 +922,7 @@ export interface DataPropertiesService {
    * @throws {ResourceUnknownError}
    */
   update(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     propertyPath: string,
     requestBody: TypeConfiguration,
     options?: OptionsBase
@@ -958,7 +947,6 @@ export interface DataSchemasService {
    * - | - | -
    * none | | Every one can use this endpoint
    * `DISABLE_SCHEMAS` | `global` | Includes disabled schemas in the response
-   * @param rql Add filters to the requested list.
    * @returns PagedResultWithPager<Schema>
    */
   find(options?: OptionsWithRql): Promise<PagedResultWithPager<Schema>>;
@@ -971,7 +959,6 @@ export interface DataSchemasService {
    * - | - | -
    * none | | Every one can use this endpoint
    * `DISABLE_SCHEMAS` | `global` | Includes disabled schemas in the response
-   * @param rql Add filters to the requested list.
    * @returns Schema[]
    */
   findAll(options?: OptionsWithRql): Promise<Schema[]>;
@@ -982,27 +969,23 @@ export interface DataSchemasService {
    * - | - | -
    * none | | Every one can use this endpoint
    * `DISABLE_SCHEMAS` | `global` | Includes disabled schemas in the response
-   * @param rql Add filters to the requested list.
    * @returns Schema[]
    */
   findAllIterator(options?: OptionsWithRql): FindAllIterator<Schema>;
   /**
    * Find By Id
    * @param id the Id to search for
-   * @param rql an optional rql string
    * @returns the first element found
    */
   findById(id: ObjectId, options?: OptionsWithRql): Promise<Schema>;
   /**
    * Find By Name
    * @param name the name to search for
-   * @param rql an optional rql string
    * @returns the first element found
    */
   findByName(name: string, options?: OptionsWithRql): Promise<Schema>;
   /**
    * Find First
-   * @param rql an optional rql string
    * @returns the first element found
    */
   findFirst(options?: OptionsWithRql): Promise<Schema>;
@@ -1012,12 +995,12 @@ export interface DataSchemasService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody The schema input
    * @returns AffectedRecords
    */
   update(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: UpdateSchemaInput,
     options?: OptionsWithRql
   ): Promise<AffectedRecords>;
@@ -1027,31 +1010,31 @@ export interface DataSchemasService {
    * Permission | Scope | Effect
    * - | - | -
    * `DELETE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns AffectedRecords
    * @throws {IllegalStateError}
    */
-  remove(schemaId: ObjectId, options?: OptionsBase): Promise<AffectedRecords>;
+  remove(schemaIdOrName: ObjectId | string, options?: OptionsBase): Promise<AffectedRecords>;
   /**
    * Disable a schema
    *
    * Permission | Scope | Effect
    * - | - | -
    * `DISABLE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns AffectedRecords
    */
-  disable(schemaId: ObjectId, options?: OptionsBase): Promise<AffectedRecords>;
+  disable(schemaIdOrName: ObjectId | string, options?: OptionsBase): Promise<AffectedRecords>;
   /**
    * Enable a schema
    *
    * Permission | Scope | Effect
    * - | - | -
    * `DISABLE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @returns AffectedRecords
    */
-  enable(schemaId: ObjectId, options?: OptionsBase): Promise<AffectedRecords>;
+  enable(schemaIdOrName: ObjectId | string, options?: OptionsBase): Promise<AffectedRecords>;
 }
 
 export interface DataStatusesService {
@@ -1061,13 +1044,13 @@ export interface DataStatusesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody The name and status data
    * @returns AffectedRecords
    * @throws {ResourceAlreadyExistsError}
    */
   create(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: {
       name: string;
       data?: StatusData;
@@ -1080,14 +1063,14 @@ export interface DataStatusesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param name The name of the targeted status.
    * @param requestBody The status data
    * @returns AffectedRecords
    * @throws {ResourceUnknownError}
    */
   update(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     name: string,
     requestBody: StatusData,
     options?: OptionsBase
@@ -1098,14 +1081,14 @@ export interface DataStatusesService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param name The name of the targeted status.
    * @returns AffectedRecords
    * @throws {StatusInUseError}
    * @throws {ResourceUnknownError}
    */
   remove(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     name: string,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
@@ -1118,13 +1101,13 @@ export interface DataTransitionsService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody
    * @returns {Promise<AffectedRecords>}
    * @throws {IllegalArgumentError}
    */
   updateCreation(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: CreationTransition,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
@@ -1134,13 +1117,13 @@ export interface DataTransitionsService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param requestBody TransitionInput
    * @returns {Promise<AffectedRecords>}
    * @throws {IllegalArgumentError}
    */
   create(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     requestBody: TransitionInput,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
@@ -1150,7 +1133,7 @@ export interface DataTransitionsService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param transitionId The id of the targeted transition.
    * @param requestBody
    * @returns {Promise<AffectedRecords>}
@@ -1158,7 +1141,7 @@ export interface DataTransitionsService {
    * @throws {ResourceUnknownError}
    */
   update(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     transitionId: ObjectId,
     requestBody: TransitionInput,
     options?: OptionsBase
@@ -1169,13 +1152,13 @@ export interface DataTransitionsService {
    * Permission | Scope | Effect
    * - | - | -
    * `UPDATE_SCHEMAS` | `global` | **Required** for this endpoint
-   * @param schemaId The id of the targeted schema.
+   * @param schemaIdOrName The id or name of the targeted schema.
    * @param transitionId The id of the targeted transition.
    * @returns {Promise<AffectedRecords>}
    * @throws {ResourceUnknownError}
    */
   remove(
-    schemaId: ObjectId,
+    schemaIdOrName: ObjectId | string,
     transitionId: ObjectId,
     options?: OptionsBase
   ): Promise<AffectedRecords>;


### PR DESCRIPTION
Also removed a description of a no longer available `rql` param