### PR TITLE
Make userIds in unlinkUsers function optional (#935)

### DIFF
--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -820,7 +820,7 @@ export interface DataDocumentsService {
     schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
     requestBody: {
-      userIds: Array<ObjectId>;
+      userIds?: Array<ObjectId>;
     },
     options?: OptionsBase
   ): Promise<AffectedRecords>;


### PR DESCRIPTION
In the jsdoc of the `unlinkFunction` it says that

> **Not** specifying the `userIds` array will **unlink all** users from the document.

This PR makes the `userIds` field optional so that it is possible to not specify it in order to unlink all users

#935