### PR TITLE
Don't require the request body to be set for unlinkGroups/unlinkUsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `exh.data.documents.unlinkAllUsers` and `unlinkAllGroups` methods to unlink all users or groups from a document
+
 ### Changed
 - RQL `contains` and `excludes` now have their different variations better separated in the type definitions
-- For both `exh.data.documents.unlinkGroups` and `unlinkUsers` the body can now be an empty object or not be provided at all
-  - Thanks to `tran-simon` for the pointing out the incorrect `unlinkUsers` type definition!
+- `exh.data.documents.unlinkUsers` and `unlinkGroups` now also accept an array of user or group ids directly rather than nested in a request body object
+  - Thanks to `tran-simon` for the pointing out the initially incorrect `unlinkUsers` type definition!
+
+### Deprecated
+- `exh.data.documents.unlinkUsers` usage with an object is deprecated in favor of an array of ids directly or `unlinkAllUsers` for unlinking all users
+- `exh.data.documents.unlinkGroups` usage with an object is deprecated in favor of an array of ids directly or `unlinkAllGroups` for unlinking all groups
 
 ## [8.4.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- RQL `contains` and `excludes` now have their different variations better separated in the type definitions
+- For both `exh.data.documents.unlinkGroups` and `unlinkUsers` the body can now be an empty object or not be provided at all
+  - Thanks to `tran-simon` for the pointing out the incorrect `unlinkUsers` type definition!
+
 ## [8.4.1]
 
 ### Fixed

--- a/src/services/data/documents.ts
+++ b/src/services/data/documents.ts
@@ -151,11 +151,13 @@ export default (
     },
 
     async unlinkGroups(schemaIdOrName, documentId, requestBody, options) {
+      const data = requestBody || {};
+
       return (
         await client.post(
           httpAuth,
           `/${schemaIdOrName}/documents/${documentId}/unlinkGroups`,
-          requestBody,
+          data,
           options
         )
       ).data;
@@ -173,11 +175,13 @@ export default (
     },
 
     async unlinkUsers(schemaIdOrName, documentId, requestBody, options) {
+      const data = requestBody || {};
+
       return (
         await client.post(
           httpAuth,
           `/${schemaIdOrName}/documents/${documentId}/unlinkUsers`,
-          requestBody,
+          data,
           options
         )
       ).data;

--- a/src/services/data/documents.ts
+++ b/src/services/data/documents.ts
@@ -150,17 +150,21 @@ export default (
       ).data;
     },
 
-    async unlinkGroups(schemaIdOrName, documentId, requestBody, options) {
-      const data = requestBody || {};
+    async unlinkGroups(schemaIdOrName, documentId, data: Array<string> | { groupIds?: Array<string>; }, options) {
+      const requestBody = Array.isArray(data) ? { groupIds: data } : data;
 
       return (
         await client.post(
           httpAuth,
           `/${schemaIdOrName}/documents/${documentId}/unlinkGroups`,
-          data,
+          requestBody,
           options
         )
       ).data;
+    },
+
+    async unlinkAllGroups(schemaIdOrName, documentId, options) {
+      return await this.unlinkGroups(schemaIdOrName, documentId, {}, options); // Empty object to remove all groups
     },
 
     async linkUsers(schemaIdOrName, documentId, requestBody, options) {
@@ -174,17 +178,21 @@ export default (
       ).data;
     },
 
-    async unlinkUsers(schemaIdOrName, documentId, requestBody, options) {
-      const data = requestBody || {};
+    async unlinkUsers(schemaIdOrName, documentId, data: Array<string> | { userIds?: Array<string>; }, options) {
+      const requestBody = Array.isArray(data) ? { userIds: data } : data;
 
       return (
         await client.post(
           httpAuth,
           `/${schemaIdOrName}/documents/${documentId}/unlinkUsers`,
-          data,
+          requestBody,
           options
         )
       ).data;
+    },
+
+    async unlinkAllUsers(schemaIdOrName, documentId, options) {
+      return await this.unlinkUsers(schemaIdOrName, documentId, {}, options); // Empty object to remove all users
     },
   };
 };

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -729,6 +729,7 @@ export interface DataDocumentsService {
     },
     options?: OptionsWithRql
   ): Promise<AffectedRecords>;
+
   /**
    * Link groups to a document
    *
@@ -750,14 +751,17 @@ export interface DataDocumentsService {
     },
     options?: OptionsBase
   ): Promise<AffectedRecords>;
+
   /**
+   * @deprecated Use `unlinkGroups(schemaIdOrName, documentId, groupIds)` or `unlinkAllGroups(schemaIdOrName, documentId)` instead.
+   *
    * Unlink groups from a document
    *
    * Unlink the specified groups from a document
    *
    * Specifying an **empty** `groupIds` array will have **no effect** on the document.
    *
-   * **Not** specifying the `groupIds` array or `requestBody` will **unlink all** groups from the document.
+   * **Not** specifying the `groupIds` array will **unlink all** groups from the document.
    *
    * Permission | Scope | Effect
    * - | - | -
@@ -770,11 +774,43 @@ export interface DataDocumentsService {
   unlinkGroups(
     schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
-    requestBody?: {
+    requestBody: {
       groupIds?: Array<ObjectId>;
     },
     options?: OptionsBase
   ): Promise<AffectedRecords>;
+
+  /**
+   * Unlink groups from a document
+   *
+   * Unlink the specified groups from a document
+   *
+   * Specifying an **empty** `groupIds` array will have **no effect** on the document.
+   *
+   * Permission | Scope | Effect
+   * - | - | -
+   * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
+   */
+  unlinkGroups(
+    schemaIdOrName: ObjectId | string,
+    documentId: ObjectId,
+    groupIds: Array<ObjectId>,
+    options?: OptionsBase
+  ): Promise<AffectedRecords>;
+
+  /**
+   * Unlink all groups from a document
+   *
+   * Permission | Scope | Effect
+   * - | - | -
+   * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
+   */
+  unlinkAllGroups(
+    schemaIdOrName: ObjectId | string,
+    documentId: ObjectId,
+    options?: OptionsBase
+  ): Promise<AffectedRecords>;
+
   /**
    * Link users to a document
    *
@@ -798,14 +834,17 @@ export interface DataDocumentsService {
     },
     options?: OptionsBase
   ): Promise<AffectedRecords>;
+
   /**
+   * @deprecated Use `unlinkUsers(schemaIdOrName, documentId, userIds)` or `unlinkAllUsers(schemaIdOrName, documentId)` instead.
+   *
    * Unlink users from a document
    *
    * Unlink the specified users from a document.
    *
    * Specifying an **empty** `userIds` array will have **no effect** on the document.
    *
-   * **Not** specifying the `userIds` array or `requestBody` will **unlink all** users from the document.
+   * **Not** specifying the `userIds` array will **unlink all** users from the document.
    *
    * Permission | Scope | Effect
    * - | - | -
@@ -820,9 +859,44 @@ export interface DataDocumentsService {
   unlinkUsers(
     schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
-    requestBody?: {
+    requestBody: {
       userIds?: Array<ObjectId>;
     },
+    options?: OptionsBase
+  ): Promise<AffectedRecords>;
+
+  /**
+   * Unlink users from a document
+   *
+   * Unlink the specified users from a document.
+   *
+   * Specifying an **empty** `userIds` array will have **no effect** on the document.
+   *
+   * Permission | Scope | Effect
+   * - | - | -
+   * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
+   *
+   * Note: When GroupSyncMode.LINKED_USERS_PATIENT_ENLISTMENT is set for a document, all the groups where the specified user is enlisted as patient will also be removed from the document.
+   */
+  unlinkUsers(
+    schemaIdOrName: ObjectId | string,
+    documentId: ObjectId,
+    userIds: Array<ObjectId>,
+    options?: OptionsBase
+  ): Promise<AffectedRecords>;
+
+  /**
+   * Unlink all users from a document
+   *
+   * Permission | Scope | Effect
+   * - | - | -
+   * `UPDATE_ACCESS_TO_DOCUMENT` | `global` | **Required** for this endpoint
+   *
+   * Note: When GroupSyncMode.LINKED_USERS_PATIENT_ENLISTMENT is set for a document, all the groups where the specified user is enlisted as patient will also be removed from the document.
+   */
+  unlinkAllUsers(
+    schemaIdOrName: ObjectId | string,
+    documentId: ObjectId,
     options?: OptionsBase
   ): Promise<AffectedRecords>;
 }

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -757,7 +757,7 @@ export interface DataDocumentsService {
    *
    * Specifying an **empty** `groupIds` array will have **no effect** on the document.
    *
-   * **Not** specifying the `groupIds` array will **unlink all** groups from the document.
+   * **Not** specifying the `groupIds` array or `requestBody` will **unlink all** groups from the document.
    *
    * Permission | Scope | Effect
    * - | - | -
@@ -770,7 +770,7 @@ export interface DataDocumentsService {
   unlinkGroups(
     schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
-    requestBody: {
+    requestBody?: {
       groupIds?: Array<ObjectId>;
     },
     options?: OptionsBase
@@ -805,7 +805,7 @@ export interface DataDocumentsService {
    *
    * Specifying an **empty** `userIds` array will have **no effect** on the document.
    *
-   * **Not** specifying the `userIds` array will **unlink all** users from the document.
+   * **Not** specifying the `userIds` array or `requestBody` will **unlink all** users from the document.
    *
    * Permission | Scope | Effect
    * - | - | -
@@ -820,7 +820,7 @@ export interface DataDocumentsService {
   unlinkUsers(
     schemaIdOrName: ObjectId | string,
     documentId: ObjectId,
-    requestBody: {
+    requestBody?: {
       userIds?: Array<ObjectId>;
     },
     options?: OptionsBase

--- a/tests/unit/data/documentsService.test.ts
+++ b/tests/unit/data/documentsService.test.ts
@@ -164,12 +164,24 @@ describe('Documents Service', () => {
       expect(response.affectedRecords).toBe(1);
     });
 
-    it('Unlinks all groups from a document', async () => {
+    it('Unlinks all groups from a document when supplying an empty object', async () => {
       nock(`${host}${DATA_BASE}`)
-        .post(`/${schemaId}/documents/${documentId}/unlinkGroups`)
+        .post(`/${schemaId}/documents/${documentId}/unlinkGroups`, {})
         .reply(200, { affectedRecords: 1 });
 
       const response = await sdk.data.documents.unlinkGroups(schemaId, documentId, {});
+
+      expect(response.affectedRecords).toBe(1);
+    });
+
+    it('Unlinks all groups from a document when no request body is supplied', async () => {
+      nock(`${host}${DATA_BASE}`)
+        // Empty object needs to be supplied, even if the request body is not supplied by the user
+        // Although couldn't make the test fail (nock seems to implicitly convert undefined to `{}`) just here for completeness
+        .post(`/${schemaId}/documents/${documentId}/unlinkGroups`, {})
+        .reply(200, { affectedRecords: 1 });
+
+      const response = await sdk.data.documents.unlinkGroups(schemaId, documentId);
 
       expect(response.affectedRecords).toBe(1);
     });
@@ -185,14 +197,39 @@ describe('Documents Service', () => {
     expect(res.affectedRecords).toBe(1);
   });
 
-  it('should unlink users from a document', async () => {
-    nock(`${host}${DATA_BASE}`)
-      .post(`/${schemaId}/documents/${documentId}/unlinkUsers`)
-      .reply(200, { affectedRecords: 1 });
-    const res = await sdk.data.documents.unlinkUsers(schemaId, documentId, {
-      userIds: ['5e9fff9d90135a2a9a718e2f'],
+  describe('unlinkUsers', () => {
+    it('Unlinks a specific user from a document', async () => {
+      nock(`${host}${DATA_BASE}`)
+        .post(`/${schemaId}/documents/${documentId}/unlinkUsers`, {
+          userIds: ['5e9fff9d90135a2a9a718e2f'],
+        })
+        .reply(200, { affectedRecords: 1 });
+
+      const res = await sdk.data.documents.unlinkUsers(schemaId, documentId, {
+        userIds: ['5e9fff9d90135a2a9a718e2f'],
+      });
+      expect(res.affectedRecords).toBe(1);
     });
-    expect(res.affectedRecords).toBe(1);
+
+    it('Unlinks all users from a document when an empty object is supplied', async () => {
+      nock(`${host}${DATA_BASE}`)
+        .post(`/${schemaId}/documents/${documentId}/unlinkUsers`, {})
+        .reply(200, { affectedRecords: 1 });
+
+      const res = await sdk.data.documents.unlinkUsers(schemaId, documentId, {});
+      expect(res.affectedRecords).toBe(1);
+    });
+
+    it('Unlinks all users from a document when no request body is supplied', async () => {
+      nock(`${host}${DATA_BASE}`)
+        // Empty object needs to be supplied, even if the request body is not supplied by the user
+        // Although couldn't make the test fail (nock seems to implicitly convert undefined to `{}`) just here for completeness
+        .post(`/${schemaId}/documents/${documentId}/unlinkUsers`, {})
+        .reply(200, { affectedRecords: 1 });
+
+      const res = await sdk.data.documents.unlinkUsers(schemaId, documentId);
+      expect(res.affectedRecords).toBe(1);
+    });
   });
 
   it('should return true if the document is not in a locked state', async () => {

--- a/tests/unit/data/documentsService.test.ts
+++ b/tests/unit/data/documentsService.test.ts
@@ -152,9 +152,23 @@ describe('Documents Service', () => {
   });
 
   describe('unlinkGroups', () => {
-    it('Unlinks specific groups from a document', async () => {
+    it('Unlinks specific groups from a document when supplying group ids', async () => {
       nock(`${host}${DATA_BASE}`)
-        .post(`/${schemaId}/documents/${documentId}/unlinkGroups`)
+        .post(`/${schemaId}/documents/${documentId}/unlinkGroups`, {
+          groupIds: ['5e9fff9d90135a2a9a718e2f'],
+        })
+        .reply(200, { affectedRecords: 1 });
+
+      const response = await sdk.data.documents.unlinkGroups(schemaId, documentId, ['5e9fff9d90135a2a9a718e2f']);
+
+      expect(response.affectedRecords).toBe(1);
+    });
+
+    it('Unlinks specific groups from a document when supplying a request body w/ group ids', async () => {
+      nock(`${host}${DATA_BASE}`)
+        .post(`/${schemaId}/documents/${documentId}/unlinkGroups`, {
+          groupIds: ['5e9fff9d90135a2a9a718e2f'],
+        })
         .reply(200, { affectedRecords: 1 });
 
       const response = await sdk.data.documents.unlinkGroups(schemaId, documentId, {
@@ -173,15 +187,15 @@ describe('Documents Service', () => {
 
       expect(response.affectedRecords).toBe(1);
     });
+  });
 
-    it('Unlinks all groups from a document when no request body is supplied', async () => {
+  describe('unlinkAllGroups', () => {
+    it('Unlinks all groups from a document', async () => {
       nock(`${host}${DATA_BASE}`)
-        // Empty object needs to be supplied, even if the request body is not supplied by the user
-        // Although couldn't make the test fail (nock seems to implicitly convert undefined to `{}`) just here for completeness
         .post(`/${schemaId}/documents/${documentId}/unlinkGroups`, {})
         .reply(200, { affectedRecords: 1 });
 
-      const response = await sdk.data.documents.unlinkGroups(schemaId, documentId);
+      const response = await sdk.data.documents.unlinkAllGroups(schemaId, documentId);
 
       expect(response.affectedRecords).toBe(1);
     });
@@ -198,7 +212,18 @@ describe('Documents Service', () => {
   });
 
   describe('unlinkUsers', () => {
-    it('Unlinks a specific user from a document', async () => {
+    it('Unlinks specific users from a document when supplying user ids', async () => {
+      nock(`${host}${DATA_BASE}`)
+        .post(`/${schemaId}/documents/${documentId}/unlinkUsers`, {
+          userIds: ['5e9fff9d90135a2a9a718e2f'],
+        })
+        .reply(200, { affectedRecords: 1 });
+
+      const res = await sdk.data.documents.unlinkUsers(schemaId, documentId, ['5e9fff9d90135a2a9a718e2f']);
+      expect(res.affectedRecords).toBe(1);
+    });
+
+    it('Unlinks specific users from a document when supplying a body with user ids', async () => {
       nock(`${host}${DATA_BASE}`)
         .post(`/${schemaId}/documents/${documentId}/unlinkUsers`, {
           userIds: ['5e9fff9d90135a2a9a718e2f'],
@@ -219,15 +244,15 @@ describe('Documents Service', () => {
       const res = await sdk.data.documents.unlinkUsers(schemaId, documentId, {});
       expect(res.affectedRecords).toBe(1);
     });
+  });
 
-    it('Unlinks all users from a document when no request body is supplied', async () => {
+  describe('unlinkAllUsers', () => {
+    it('Unlinks all users from a document', async () => {
       nock(`${host}${DATA_BASE}`)
-        // Empty object needs to be supplied, even if the request body is not supplied by the user
-        // Although couldn't make the test fail (nock seems to implicitly convert undefined to `{}`) just here for completeness
         .post(`/${schemaId}/documents/${documentId}/unlinkUsers`, {})
         .reply(200, { affectedRecords: 1 });
 
-      const res = await sdk.data.documents.unlinkUsers(schemaId, documentId);
+      const res = await sdk.data.documents.unlinkAllUsers(schemaId, documentId);
       expect(res.affectedRecords).toBe(1);
     });
   });


### PR DESCRIPTION
Extending on the point made in #935, the UX for this is not great.

After discussion:

Deprecated:
```js
exh.data.documents.unlinkGroups(schemaId, documentId, {})
exh.data.documents.unlinkGroups(schemaId, documentId, { groupIds: ['58d1047f52faff0007680834'] })
```

Introduced:
```js
exh.data.documents.unlinkAllGroups(schemaId, documentId)
exh.data.documents.unlinkGroups(schemaId, documentId, ['58d1047f52faff0007680834']) // Overloads current method
```
