### PR TITLE
Small TemplateArrayConfiguration type correction

### DIFF
--- a/src/services/templates/types.ts
+++ b/src/services/templates/types.ts
@@ -47,6 +47,7 @@ export interface TemplateObjectConfiguration {
 
 export interface TemplateArrayConfiguration {
   type: 'array';
+  type_configuration: TemplateTypeConfiguration;
   options?: TemplateArrayOption[];
 }
 


### PR DESCRIPTION
Found the replacement of `items` in the template service V1 😄