### PR TITLE
EXH-1281 Expose a ServiceNotFoundError

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -309,6 +309,7 @@ export class ActivationRequestTimeoutError extends ForbiddenError {}
 // 404 Not Found
 export class NotFoundError extends ApiError {}
 export class ResourceUnknownError extends NotFoundError {}
+export class ServiceNotFoundError extends NotFoundError {}
 export class NoConfiguredAppStoreProduct extends NotFoundError {}
 
 // 500 Server Error
@@ -492,6 +493,7 @@ export const ErrorClassMap = {
   414: StatusInUseError,
   415: LockedDocumentError,
   801: DefaultLocalizationMissingError,
+  903: ServiceNotFoundError,
   1002: LocalizationKeyMissingError,
   1003: TemplateFillingError,
   1004: TemplateSyntaxError,

--- a/tests/unit/templates/templatesService.test.ts
+++ b/tests/unit/templates/templatesService.test.ts
@@ -5,6 +5,7 @@ import {
   createClient,
   rqlBuilder,
   ParamsOauth2,
+  ServiceNotFoundError,
 } from '../../../src/index';
 import { templateData, templateInput } from '../../__helpers__/template';
 import { createPagedResponse } from '../../__helpers__/utils';
@@ -245,5 +246,16 @@ describe('Template Service', () => {
     );
 
     expect(res).toBeDefined();
+  });
+
+  it('Throws when the service is not deployed', async () => {
+    nock(`${host}${TEMPLATE_BASE}`).get('/health')
+      .reply(404, {
+        code: 903,
+        name: 'SERVICE_NOT_FOUND_EXCEPTION',
+        message: 'The requested service could not be found',
+      });
+
+    await expect(sdk.templates.health()).rejects.toThrow(ServiceNotFoundError);
   });
 });


### PR DESCRIPTION
I've created a test on the /health of the v1 template service, but in reality any endpoint will (be able to) throw this error.
Going to be used/needed for a proper fallback in the CLI for `exh templates get`, `exh templates list` and `exh templates delete` when V1 is no longer running on (some/most) clusters later