### PR TITLE
Forward all options in findAllGeneric to the `find` functions

### DIFF
--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -53,6 +53,7 @@ export async function findAllGeneric<T>(
   // Extra check is needed because this function is call recursively with updated RQL
   // But on the first run, we need to set the limit to the max to optimize
   const result: PagedResult<T> = await find({
+    ...options,
     rql:
       options?.rql && options.rql.includes('limit(') ?
         options.rql :
@@ -71,6 +72,7 @@ export async function findAllGeneric<T>(
       ...(await findAllGeneric(
         find,
         {
+          ...options,
           rql: rqlBuilder(options?.rql)
             .limit(result.page.limit, result.page.offset + result.page.limit)
             .build(),
@@ -90,6 +92,7 @@ export function addPagersFn<T>(
 
   async function previous() {
     result = await find({
+      ...options,
       rql: rqlBuilder(options?.rql)
         .limit(
           result.page.limit,
@@ -102,6 +105,7 @@ export function addPagersFn<T>(
 
   async function next() {
     result = await find({
+      ...options,
       rql: rqlBuilder(options?.rql)
         .limit(
           result.page.limit,

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,0 +1,62 @@
+import { OptionsWithRql, rqlBuilder } from '../../src';
+import { findAllGeneric } from '../../src/services/helpers';
+
+describe('Helpers', () => {
+  describe('findAllGeneric', () => {
+    let findMock: jest.Mock;
+
+    const firstPage = {
+      data: [1, 2, 3],
+      page: {
+        total: 5,
+        limit: 3,
+        offset: 0,
+      },
+    };
+
+    const secondPage = {
+      data: [4, 5],
+      page: {
+        total: 5,
+        limit: 3,
+        offset: 3,
+      },
+    };
+
+    beforeEach(() => {
+      findMock = jest.fn()
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+    });
+
+    it('Iterates through multiple pages and returns all results', async () => {
+      const results = await findAllGeneric(findMock, undefined);
+      expect(results).toStrictEqual([1, 2, 3, 4, 5]);
+      expect(findMock).toHaveBeenCalledTimes(2);
+      expect(findMock).toHaveBeenNthCalledWith(1, { rql: '?limit(50)' });
+      expect(findMock).toHaveBeenNthCalledWith(2, { rql: '?limit(3,3)' });
+    });
+
+    it('Applies all options supplied to all calls to `find`', async () => {
+      const options: OptionsWithRql = {
+        rql: rqlBuilder().eq('field', 'value').build(),
+        headers: { 'X-Custom-Header': 'CustomValue' },
+        shouldRetry: true,
+      };
+
+      await findAllGeneric(findMock, options);
+
+      expect(findMock).toHaveBeenNthCalledWith(1, {
+        rql: '?eq(field,value)&limit(50)',
+        headers: { 'X-Custom-Header': 'CustomValue' },
+        shouldRetry: true,
+      });
+
+      expect(findMock).toHaveBeenNthCalledWith(2, {
+        rql: '?eq(field,value)&limit(3,3)',
+        headers: { 'X-Custom-Header': 'CustomValue' },
+        shouldRetry: true,
+      });
+    });
+  });
+});

--- a/tests/unit/mails/mailsService.test.ts
+++ b/tests/unit/mails/mailsService.test.ts
@@ -77,13 +77,15 @@ describe('Mail Service', () => {
   it('Finds all mails', async () => {
     nock(`${host}${MAIL_BASE}`)
       .get('/?limit(50)')
+      .matchHeader('X-Custom-Header', 'value')
       .reply(200, createPagedResponse([mailData], { total: 2, offset: 0, limit: 1 }));
 
     nock(`${host}${MAIL_BASE}`)
       .get('/?limit(1,1)')
+      .matchHeader('X-Custom-Header', 'value')
       .reply(200, createPagedResponse([mailData], { total: 2, offset: 1, limit: 1 }));
 
-    const mails = await sdk.mails.findAll();
+    const mails = await sdk.mails.findAll({ headers: { 'X-Custom-Header': 'value' } });
 
     expect(mails[0].id).toBe(mailId);
     expect(mails[1].id).toBe(mailId);


### PR DESCRIPTION
Address the issue mentioned in #1049 