### PR TITLE
Explicitly disallow skipCount to be used in findAll

### DIFF
--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -45,8 +45,14 @@ export async function findAllGeneric<T>(
   options: OptionsWithRql | undefined,
   level = 1
 ): Promise<T[]> {
-  if (level === 1 && options?.rql && options.rql.includes('limit(')) {
-    throw new Error('Do not pass in limit operator with findAll');
+  if (level === 1 && options?.rql) {
+    if (options.rql.includes('limit(')) {
+      throw new Error('Do not pass in limit operator with findAll');
+    }
+
+    if (options.rql.includes('skipCount(')) {
+      throw new Error('Do not pass in skipCount operator with findAll');
+    }
   }
 
   // return async options => {

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -58,5 +58,21 @@ describe('Helpers', () => {
         shouldRetry: true,
       });
     });
+
+    it('Throws when limit is already set in the RQL', async () => {
+      const options: OptionsWithRql = {
+        rql: rqlBuilder().limit(10).build(),
+      };
+
+      await expect(findAllGeneric(findMock, options)).rejects.toThrow('Do not pass in limit operator with findAll');
+    });
+
+    it('Throws when skipCount is set in the RQL', async () => {
+      const options: OptionsWithRql = {
+        rql: rqlBuilder().skipCount().build(),
+      };
+
+      await expect(findAllGeneric(findMock, options)).rejects.toThrow('Do not pass in skipCount operator with findAll');
+    });
   });
 });


### PR DESCRIPTION
Addresses the issue mentioned in #1029 